### PR TITLE
Fix import error in snmp tests

### DIFF
--- a/tests/config_snmp_test.py
+++ b/tests/config_snmp_test.py
@@ -12,6 +12,7 @@ import pytest
 from unittest import mock
 from unittest.mock import patch
 from utilities_common.db import Db
+from config.snmp import is_valid_email
 
 tabular_data_show_run_snmp_contact_expected = """\
 Contact    Contact Email\n---------  --------------------\ntestuser   testuser@contoso.com
@@ -862,7 +863,7 @@ class TestSNMPConfigCommands(object):
     @pytest.mark.parametrize("invalid_email", ['test@contoso', 'test.contoso.com', 'testcontoso@com', 
                                                '123_%contoso.com', 'mytest@contoso.comm'])
     def test_is_valid_email(self, invalid_email):
-        output = config.is_valid_email(invalid_email)
+        output = is_valid_email(invalid_email)
         assert output == False
 
     @classmethod


### PR DESCRIPTION
This PR fixes the next builds errors:

>12:05:21      def test_is_valid_email(self, invalid_email):
12:05:21  >       output = config.is_valid_email(invalid_email)
12:05:21  E       AttributeError: module 'config.main' has no attribute 'is_valid_email'
12:05:21  
12:05:21  tests/config_snmp_test.py:865: AttributeError
12:05:21  _______ TestSNMPConfigCommands.test_is_valid_email[mytest@contoso.comm] ________
12:05:21  
12:05:21  self = <tests.config_snmp_test.TestSNMPConfigCommands object at 0x7fee0adf6a00>
12:05:21  invalid_email = 'mytest@contoso.comm'
12:05:21  
12:05:21      @pytest.mark.parametrize("invalid_email", ['test@contoso', 'test.contoso.com', 'testcontoso@com',
12:05:21                                                 '123_%contoso.com', 'mytest@contoso.comm'])
12:05:21      def test_is_valid_email(self, invalid_email):
12:05:21  >       output = config.is_valid_email(invalid_email)
12:05:21  E       AttributeError: module 'config.main' has no attribute 'is_valid_email'
12:05:21  tests/config_snmp_test.py:865: AttributeError 


>12:05:21  
23:13:27  =========================== short test summary info ============================
23:13:27  FAILED tests/config_snmp_test.py::TestSNMPConfigCommands::test_is_valid_email[test@contoso]
23:13:27  FAILED tests/config_snmp_test.py::TestSNMPConfigCommands::test_is_valid_email[test.contoso.com]
23:13:27  FAILED tests/config_snmp_test.py::TestSNMPConfigCommands::test_is_valid_email[testcontoso@com]
23:13:27  FAILED tests/config_snmp_test.py::TestSNMPConfigCommands::test_is_valid_email[123_%contoso.com]
23:13:27  FAILED tests/config_snmp_test.py::TestSNMPConfigCommands::test_is_valid_email[mytest@contoso.comm]
23:13:27  ===== 5 failed, 1973 passed, 3 skipped, 18 warnings in 1719.41s (0:28:39) ======
23:13:27  [  FAIL LOG END  ] [ target/python-wheels/bullseye/sonic_utilities-1.2-py3-none-any.whl ]
23:20:50  326a23457510702bf3ee1b67b7ecbc149fed1e45caf1fe95478b9751463810eb
23:20:50  docker-mux
23:23:58  [ finished ] [ target/docker-mux.gz ] 
00:53:02  [ finished ] [ target/debs/bullseye/libsairedis_1.0.0_amd64.deb ] 
01:00:42  [ finished ] [ target/debs/bullseye/linux-headers-5.10.0-18-2-common_5.10.140-1_all.deb ] 
01:02:33  make[1]: *** [Makefile.work:409: target/sonic-vs.bin] Error 2
01:02:33  make[1]: Leaving directory '/tmp/jenkins-2f44a91f/workspace/vs/sonic-vs-build/174/sonic-buildimage'
01:02:33  make: *** [Makefile:33: target/sonic-vs.bin] Error 2

Issue introduced in  this commit: [Move SNMP config commands to separated file · githedgehog/sonic-utilities@d9ec860](https://github.com/githedgehog/sonic-utilities/commit/d9ec860b84b689feb0336cc86313be3fe6ae0043)